### PR TITLE
Remove event date editor border 

### DIFF
--- a/src/date/style.scss
+++ b/src/date/style.scss
@@ -4,8 +4,3 @@
  *
  * Replace them with your own styles or remove the file completely.
  */
-
-.wp-block-dc23-tea-date {
-
-	/* todo */
-}


### PR DESCRIPTION
Remove event date editor border and related placeholder styles.

This changelog entry aims to document 32a9225bbec11acf7c310041625cc8ba5affb1bd.