### PR TITLE
GHA: Clean install of NPM deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         run: 'composer validate --no-check-publish'
 
       - name: 'NPM install'
-        run: npm install
+        run: npm clean-install
 
       - name: 'Composer install'
         run: 'composer install --prefer-dist --no-progress --optimize-autoloader'


### PR DESCRIPTION
Use `npm clean-install` (commonly referred to as `npm ci`) instead of regular `npm install` in CI.

src. https://docs.npmjs.com/cli/v11/commands/npm-ci